### PR TITLE
Add iOS and Android SDK links to documentation

### DIFF
--- a/cms/SDKs/config.json
+++ b/cms/SDKs/config.json
@@ -3,7 +3,7 @@
   "icon": "fa-file-o",
   "status": "collapse",
   "title": "SDKs",
-  "description": " Coming soon...",
+  "description": "Get started with Mojio using the platform of your choice",
   "breadcrumbs": true,
   "templateURI": "~/template.md",
   "templateType": "markdown",

--- a/cms/SDKs/template.md
+++ b/cms/SDKs/template.md
@@ -1,3 +1,9 @@
-# SDKs #
+Some of our Version 2 SDKs are currently still in development. If you're daring, feel free to check them out on the develop branch in their respective repos below. Documentation for each SDK can be found on each Github page.
 
-Our Version 2 SDKs are currently still in development, but you can check out our V1 [C#](https://github.com/mojio/Mojio.Client), [Javascript](https://github.com/mojio/mojio-js) and [PHP](https://github.com/mojio/mojio-php-client) SDKs in the meantime.
+| Language      | Github                                     | 
+| ------------- | ------------------------------------------ |
+| Android       | https://github.com/mojio/mojio-android-sdk |
+| C#      	    | https://github.com/mojio/Mojio.Client      |
+| iOS 		    | https://github.com/mojio/mojio-ios-sdk     |
+| JavaScript    | https://github.com/mojio/mojio-js          |
+| PHP           | https://github.com/mojio/mojio-php-client  |

--- a/cms/SDKs/template.md
+++ b/cms/SDKs/template.md
@@ -5,7 +5,7 @@ Our client SDKs are 100% open source. Documentation and specifics for each SDK c
 | Language      | Github                                     | 
 | ------------- | ------------------------------------------ |
 | Android       | https://github.com/mojio/mojio-android-sdk |
-| C#      	    | https://github.com/mojio/Mojio.Client      |
-| iOS 		    | https://github.com/mojio/mojio-ios-sdk     |
+| C#            | https://github.com/mojio/Mojio.Client      |
+| iOS           | https://github.com/mojio/mojio-ios-sdk     |
 | JavaScript    | https://github.com/mojio/mojio-js          |
 | PHP           | https://github.com/mojio/mojio-php-client  |

--- a/cms/SDKs/template.md
+++ b/cms/SDKs/template.md
@@ -1,4 +1,6 @@
-Some of our Version 2 SDKs are currently still in development. If you're daring, feel free to check them out on the develop branch in their respective repos below. Documentation for each SDK can be found on each Github page.
+Some of our Version 2 SDKs are currently still in development. If you're daring, feel free to check them out on the *develop* branch in their respective repos below.
+
+Our client SDKs are 100% open source. Documentation and specifics for each SDK can be found on their respective Github pages.
 
 | Language      | Github                                     | 
 | ------------- | ------------------------------------------ |


### PR DESCRIPTION
Just a small change to clean up the SDKs page and add links to the Android and iOS github repos.