### PR TITLE
fix require call to MojioClientLite module

### DIFF
--- a/doc_js.md
+++ b/doc_js.md
@@ -42,7 +42,7 @@ Once you have included the SDK, connecting to our API is as simple as:
 
 First you will want to download SDK libraries. Once you have downloaded and included the SDK, connecting to our API is as simple as:
 ```
-var MojioClientLite= require("MojioClientLite");
+var MojioClientLite= require("mojio-client-lite");
 
 var config = {
     application: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',


### PR DESCRIPTION
When installed via npm, the module (folder) name in node_modules is actually "mojio-client-lite" as defined in package.json